### PR TITLE
Snips for presented picts

### DIFF
--- a/inspector.rkt
+++ b/inspector.rkt
@@ -6,7 +6,7 @@
          "private/presentation/pict.rkt"
          "private/presentation/text.rkt")
 
-(provide gui-inspect value/p)
+(provide gui-inspect value/p (rename-out [present-value present-to-pict]))
 
 (define (exact-floor n) (inexact->exact (floor n)))
 (define (exact-ceiling n) (inexact->exact (ceiling n)))
@@ -18,7 +18,8 @@
 
 (define value/p (make-presentation-type 'value/p))
 
-(define (present-value c v)
+(define/contract (present-value c v)
+  (-> (is-a?/c pict-presenter<%>) any/c pict?)
   (cond
     [(pair? v)
      (define car-pict (present-value c (car v)))

--- a/private/presentation.rkt
+++ b/private/presentation.rkt
@@ -229,7 +229,6 @@
                                 null)]
                   [cmd (tr (presentation-value pres))])
         cmd))))
-
 (define current-presentation-context
   (make-parameter (new presentation-context%)))
 

--- a/private/presentation/presentation-pict-snip.rkt
+++ b/private/presentation/presentation-pict-snip.rkt
@@ -1,0 +1,53 @@
+#lang racket
+
+(require racket/gui)
+(require "../presentation.rkt" "pict.rkt")
+
+(provide presentation-pict-snip%)
+
+(define presentation-pict-snip%
+  (class* (pict-presenter-mixin snip%)
+    (presenter<%> pict-presenter<%>)
+    (super-new)
+
+    (inherit handle-mouse-event)
+
+    (define (set-box!/ok b val)
+      (if (box? b)
+          (set-box! b val)
+          (void)))
+
+    ;; Snip methods
+    (send this set-flags (cons 'handles-all-mouse-events
+                               (cons 'handles-events
+                                     (send this get-flags))))
+
+    (define/override (get-extent dc x y
+                                 [w #f]
+                                 [h #f]
+                                 [descent #f]
+                                 [space #f]
+                                 [lspace #f]
+                                 [rspace #f])
+      (set-box!/ok w (+ 2 (send this get-draw-width)))
+      (set-box!/ok h (+ 2 (send this get-draw-height)))
+      (set-box!/ok descent 1.0)
+      (set-box!/ok space 1.0)
+      (set-box!/ok lspace 0)
+      (set-box!/ok rspace 0))
+
+    (define/override (draw dc x y left top right bottom dx dy draw-caret)
+      (define smoothing (send dc get-smoothing))
+      (define pen (send dc get-pen))
+      (send this draw-picts dc x y)
+      (send dc set-smoothing smoothing)
+      (send dc set-pen pen))
+
+    (define/override (on-event dc x y editor-x editor-y ev)
+      ;; Here we must pretend that we are running all mouse events
+      ;; relative to global rather than local coordinates, because
+      ;; when the presentation-picts register themselves, they only
+      ;; know about the DC in which they are found.
+      (handle-mouse-event ev 0 0))))
+
+

--- a/private/presentation/presentation-pict-snip.rkt
+++ b/private/presentation/presentation-pict-snip.rkt
@@ -17,6 +17,11 @@
           (set-box! b val)
           (void)))
 
+    (define/override (show-popup-menu menu x y)
+      (define admin (send this get-admin))
+      (when admin
+        (send admin popup-menu menu this x y)))
+
     ;; Snip methods
     (send this set-flags (cons 'handles-all-mouse-events
                                (cons 'handles-events
@@ -29,8 +34,8 @@
                                  [space #f]
                                  [lspace #f]
                                  [rspace #f])
-      (set-box!/ok w (+ 2 (send this get-draw-width)))
-      (set-box!/ok h (+ 2 (send this get-draw-height)))
+      (set-box!/ok w (send this get-draw-width))
+      (set-box!/ok h (send this get-draw-height))
       (set-box!/ok descent 1.0)
       (set-box!/ok space 1.0)
       (set-box!/ok lspace 0)
@@ -44,10 +49,13 @@
       (send dc set-pen pen))
 
     (define/override (on-event dc x y editor-x editor-y ev)
-      ;; Here we must pretend that we are running all mouse events
-      ;; relative to global rather than local coordinates, because
-      ;; when the presentation-picts register themselves, they only
-      ;; know about the DC in which they are found.
-      (handle-mouse-event ev 0 0))))
+      (define ev-x (send ev get-x))
+      (define ev-y (send ev get-y))
+      (when (and ev-x (<= 0 (- ev-x x) (send this get-draw-width))
+                 ev-y (<= 0 (- ev-y y) (send this get-draw-height)))
+        (handle-mouse-event ev x y)))
+
+    (define/override (adjust-cursor dc x y ed-x ed-y ev)
+      (make-object cursor% 'arrow))))
 
 

--- a/private/presentation/repl.rkt
+++ b/private/presentation/repl.rkt
@@ -65,9 +65,12 @@
         (let ((was-locked? locked?)
               (insertion-base (last-position)))
           (set! locked? #f)
-          (if (is-a? str presentation-string<%>)
-              (insert-presenting str)
-              (insert str))
+          (cond [(is-a? str presentation-string<%>)
+                 (insert-presenting str)]
+                [(string? str)
+                 (insert str)]
+                [(is-a? str snip%)
+                 (insert str)])
           (set! locked? was-locked?)))))
 
     (queue-callback insert-prompt)))

--- a/racket-repl.rkt
+++ b/racket-repl.rkt
@@ -84,7 +84,7 @@
   (real-pretty-present object 0))
 
 (module+ main
-  (define show-graphical? #t)
+  (define show-graphical? #f)
 
   (send (current-presentation-context) register-command-translator
         value/p
@@ -102,6 +102,12 @@
           (pretty-present result))))
 
   (define frame (new frame% [label "REPL"] [width 800] [height 600]))
+  (define stacking (new vertical-panel% [parent frame]))
+  (define option (new check-box%
+                      [parent stacking]
+                      [label "Output graphics"]
+                      [callback (lambda (c ev)
+                                  (set! show-graphical? (send c get-value)))]))
   (define repl (new presentation-repl%
                     [highlight-callback
                      (lambda (dc x1 y1 x2 y2)
@@ -115,6 +121,6 @@
                          (set-pen old-pen)))]
                     [eval-callback rep]))
   (define editor-canvas (new editor-canvas%
-                             [parent frame]
+                             [parent stacking]
                              [editor repl]))
   (send frame show #t))

--- a/racket-repl.rkt
+++ b/racket-repl.rkt
@@ -4,7 +4,8 @@
 (require pict)
 (require "private/presentation.rkt"
          "private/presentation/repl.rkt"
-         "private/presentation/text.rkt")
+         "private/presentation/text.rkt"
+         "private/presentation/presentation-pict-snip.rkt")
 
 (require "inspector.rkt")
 
@@ -83,6 +84,8 @@
   (real-pretty-present object 0))
 
 (module+ main
+  (define show-graphical? #t)
+
   (send (current-presentation-context) register-command-translator
         value/p
         (lambda (val)
@@ -91,8 +94,12 @@
   (define (rep str)
     (with-handlers ([exn? present-exn])
       (define result (eval (with-input-from-string str (thunk (read)))
-                           (make-base-namespace)))
-      (pretty-present result)))
+                          (make-base-namespace)))
+      (if show-graphical?
+          (let ([snip (new presentation-pict-snip%)])
+            (send snip add-pict (present-to-pict snip result) 1 1)
+            snip)
+          (pretty-present result))))
 
   (define frame (new frame% [label "REPL"] [width 800] [height 600]))
   (define repl (new presentation-repl%


### PR DESCRIPTION
Now, `presentation-text%` can contain snips that present as non-text. In particular, presenting picts can now be embedded in a `presentation-text%`.
